### PR TITLE
Add dependency resolution and sync action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem 'chefspec',   '~> 3.0'
 gem 'foodcritic', '~> 3.0'
 gem 'rubocop',    '~> 0.12'
 
+gem 'open-uri'
+
 group :integration do
   gem 'test-kitchen',    '~> 1.0.0.beta'
   gem 'kitchen-vagrant', '~> 0.11'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,4 @@
 
 default['pacman']['build_dir'] = "#{Chef::Config[:file_cache_path]}/builds"
 default['pacman']['build_user'] = 'nobody'
+default['pacman']['build_group'] = 'nobody'

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -19,150 +19,312 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
+require 'tsort'
+require 'open-uri'
 include Chef::Mixin::ShellOut
 
-def build_aur node, new_resource
-  get_pkg_version
-  aurfile = "#{new_resource.builddir}/#{new_resource.name}/#{new_resource.name}-#{new_resource.version}.pkg.tar.xz"
-  package_namespace = new_resource.name[0..1]
+def aurfile_path target, build_dir
+    target_build = ::File.join build_dir, target.name, target.name
+    aurfiles = ::Dir["#{target_build}-*.pkg.tar.xz"]
+    if aurfiles.length == 0
+        "#{target_build}-#{target.version}-#{target.arch}.pkg.tar.xz"
+    else
+        aurfiles[0]
+    end
+end
 
-  Chef::Log.debug("Checking for #{aurfile}")
-  unless ::File.exists?(aurfile)
+def already_built? target, build_dir
+    ::File.exists? aurfile_path(target, build_dir)
+end
+
+def build_aur target, opts
+    pkgbuild = ::File.join opts.build_dir, target.name, "PKGBUILD"
+    aurfile = aurfile_path target, opts.build_dir
+
     Chef::Log.debug("Creating build directory")
-    d = directory new_resource.builddir do
-      owner node['pacman']['build_user']
-      group node['pacman']['build_user']
-      mode 0755
-      action :nothing
+    directory "build_dir_#{target.name}" do
+        path opts.build_dir
+        owner opts.build_user
+        group opts.build_group
+        mode 0755
+        action :create
     end
-    d.run_action(:create)
 
-    Chef::Log.debug("Retrieving source for #{new_resource.name}")
-    r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
-      source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{new_resource.name}.tar.gz"
-      owner node['pacman']['build_user']
-      group node['pacman']['build_user']
-      mode 0644
-      action :nothing
-    end
-    r.run_action(:create_if_missing)
-
-    Chef::Log.debug("Untarring source package for #{new_resource.name}")
-    e = execute "tar -xf #{new_resource.name}.tar.gz" do
-      cwd new_resource.builddir
-      user node['pacman']['build_user']
-      group node['pacman']['build_user']
-      action :nothing
-    end
-    e.run_action(:run)
-
-    if new_resource.pkgbuild_src
-      Chef::Log.debug("Replacing PKGBUILD with custom version")
-      pkgb = cookbook_file "#{new_resource.builddir}/#{new_resource.name}/PKGBUILD" do
-        source "PKGBUILD"
-        owner node['pacman']['build_user']
-        group node['pacman']['build_user']
+    Chef::Log.debug("Retrieving source for #{target.name}")
+    remote_file ::File.join opts.build_dir, "#{target.name}.tar.gz" do
+        source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{target.name}.tar.gz"
+        owner opts.build_user
+        group opts.build_group
         mode 0644
-        action :nothing
-      end
-      pkgb.run_action(:create)
+        action :create_if_missing
     end
 
-    if new_resource.patches.length > 0
-      Chef::Log.debug("Adding new patches")
-      new_resource.patches.each do |patch|
-        pfile = cookbook_file ::File.join(new_resource.builddir, new_resource.name, patch) do
-          source patch
-          mode 0644
-          action :nothing
+    Chef::Log.debug("Untarring source package for #{target.name}")
+    execute "tar -xf #{target.name}.tar.gz" do
+        cwd opts.build_dir
+        user opts.build_user
+        group opts.build_group
+        action :run
+    end
+
+    if opts.pkgbuild_src
+        Chef::Log.debug("Replacing PKGBUILD with custom version")
+        cookbook_file pkgbuild do
+            source "PKGBUILD"
+            owner opts.build_user
+            group opts.build_group
+            mode 0644
+            action :create
         end
-        pfile.run_action(:create)
-      end
+    end
+
+    if opts.patches.length > 0
+        Chef::Log.debug("Adding new patches")
+        opts.patches.each do |patch|
+            cookbook_file ::File.join opts.build_dir, target.name, patch do
+                source patch
+                mode 0644
+                action :create
+            end
+        end
     end
 
     if new_resource.options
-      Chef::Log.debug("Appending #{new_resource.options} to configure command")
-      opt = Chef::Util::FileEdit.new("#{new_resource.builddir}/#{new_resource.name}/PKGBUILD")
-      opt.search_file_replace(/(.\/configure.+$)/, "\\1 #{new_resource.options}")
-      opt.write_file
+        Chef::Log.debug("Appending #{opts.options} to configure command")
+        opt = Chef::Util::FileEdit.new pkgbuild
+        opt.search_file_replace(/(.\/configure.+$)/, "\\1 #{opts.options}")
+        opt.write_file
     end
 
-    if new_resource.skippgpcheck
-      skippgpcheck = ' --skippgpcheck'
-    else
-      ''
-    end
+    skippgpcheck = opts.skippgpcheck ? " --skippgpcheck" : ""
 
-    Chef::Log.debug("Building package #{new_resource.name}")
-    em = execute "makepkg -s --noconfirm #{skippgpcheck}" do
-      cwd ::File.join(new_resource.builddir, new_resource.name)
-      creates aurfile
-      user node['pacman']['build_user']
-      group node['pacman']['build_user']
-      action :nothing
+    Chef::Log.debug("Building package #{target.name}")
+    execute "makepkg #{target.name}" do
+        command "makepkg -sf --noconfirm#{skippgpcheck}"
+        cwd ::File.join opts.build_dir, target.name
+        creates aurfile
+        user opts.build_user
+        group opts.build_group
+        action :run
     end
-    em.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
 end
 
-def install_aur new_resource
-  get_pkg_version
-
-  unless @aurpkg.exists && new_resource.version == @aurpkg.installed_version
-    execute "install AUR package #{new_resource.name}-#{new_resource.version}" do
-      command "pacman -U --noconfirm  --noprogressbar #{new_resource.builddir}/#{new_resource.name}/#{new_resource.name}-#{new_resource.version}.pkg.tar.xz"
+def install_aur target, opts
+    execute "install AUR package #{target.name}" do
+        command lazy {
+            aurfile = aurfile_path target, opts.build_dir
+            "pacman -U --noconfirm  --noprogressbar #{aurfile}"
+        }
     end
-    new_resource.updated_by_last_action(true)
-  end
+end
+
+def install_with_deps target, opts
+    deps = target.all_dependencies.ordered
+    deps.reject { |p| p.already_installed? }
+    .each do |package|
+        Chef::Log.debug("Installing #{package} as a dependency of #{target}")
+        if package.is_aur?
+            if not already_built? package, opts.build_dir
+                build_aur package, opts
+            end
+            install_aur package, opts
+        else
+            pacman_package package.name
+        end
+    end
 end
 
 action :build do
-  build_aur node, new_resource
+    target = Package.aur new_resource.package_name
+    opts = new_resource
+
+    Chef::Log.debug("Checking for #{aurfile_path target, opts.build_dir}")
+    if not already_built? target, build_dir
+        build_aur target, opts
+        new_resource.updated_by_last_action true
+    end
 end
 
 action :install do
-  install_aur new_resource
+    target = Package.aur new_resource.package_name
+    if not target.already_installed?
+        install_aur target, new_resource
+        new_resource.updated_by_last_action true
+    end
 end
 
 action :sync do
-  load_current_resource
-  unless @aurpkg.exists && new_resource.version == @aurpkg.installed_version
-    build_aur node, new_resource
-    install_aur new_resource
-  end
-end
-
-def get_pkg_version
-  v = ''
-  r = ''
-  a = ''
-  if ::File.exists?("#{new_resource.builddir}/#{new_resource.name}/PKGBUILD")
-    ::File.open("#{new_resource.builddir}/#{new_resource.name}/PKGBUILD").each do |line|
-      v = line.split("=")[1].chomp if line =~ /^pkgver=/
-      r = line.split("=")[1].chomp if line =~ /^pkgrel=/
-      if line =~ /^arch/
-        if line.match 'any'
-          a = 'any'
-        else
-          a = node[:kernel][:machine]
-        end
-      end
+    target = Package.aur new_resource.package_name
+    if not target.already_installed?
+        install_with_deps target, new_resource
+        new_resource.updated_by_last_action true
     end
-    Chef::Log.debug("Setting version of #{new_resource.name} to #{v}-#{r}-#{a}")
-    new_resource.version("#{v}-#{r}-#{a}")
-  end
 end
 
-def load_current_resource
-  @aurpkg = Chef::Resource::PacmanAur.new(new_resource.name)
-  @aurpkg.package_name(new_resource.package_name)
+class Package
+    attr_reader :name, :version, :arch, :dependents
 
-  Chef::Log.debug("Checking pacman for #{new_resource.package_name}")
-  p = shell_out("pacman -Qi #{new_resource.package_name}")
-  exists = p.stdout.include?(new_resource.package_name)
-  @aurpkg.exists(exists)
-  p.stdout.match(/Version +: ([\w.-]+).+Architecture +: (\w+)/m) do |match|
-    @aurpkg.installed_version("#{match[1]}-#{match[2]}")
-  end
+    @@version_arch_re = /Version +: ([\w.-]+).+Architecture +: (\w+)/m
+    @@default_arch = RUBY_PLATFORM.split("-")[0]
+
+    def initialize name, is_aur
+        info = Package.fetch_latest_info name, is_aur
+        @name = name
+        @is_aur = is_aur
+        @version = info[:version]
+        @arch = info[:arch]
+        @dependents = info[:dependents]
+        @installed = Package.installed_info name
+    end
+
+    def self.aur name
+        Package.new name, true
+    end
+
+    def self.pacman name
+        Package.new name, false
+    end
+
+    def to_s
+        if @is_aur
+            "Aur(#{@name}-#{@version})"
+        else
+            "Pacman(#{@name}-#{@version})"
+        end
+    end
+
+    def eql? other
+        @name == other.name
+    end
+
+    def hash
+        @name.hash
+    end
+
+    def is_aur?
+        @is_aur
+    end
+
+    def already_installed?
+        @installed && @version == @installed[:version]
+    end
+
+    def all_dependencies
+        AurDeps.new self
+    end
+
+    private
+
+    def self.pkgbuild_url name
+        "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=#{name}"
+    end
+
+    def self.shell command
+        Mixlib::ShellOut.new(command,
+            :user => "nobody",
+            :group => "nobody",
+            :cwd => "/tmp",
+        ).run_command.stdout.strip
+    end
+
+    def self.fetch_latest_info name, is_aur
+        if is_aur
+            pkgbuild = open(Package.pkgbuild_url name).read
+            command = <<-FIN
+                #{pkgbuild}
+                echo
+                echo version ${pkgver}-${pkgrel}
+                echo arch ${arch}
+                echo depends ${depends[@]} ${makedepends[@]}
+            FIN
+            parser = Mixlib::ShellOut.new(command,
+                :user => "nobody",
+                :group => "nobody",
+                :cwd => "/tmp",
+                :timeout => 1)
+            data = parser.run_command.stdout.strip.split("\n").last 3
+            {
+                :version => data[0].strip.split[1],
+                :arch => data[1].include?("any") ? "any" : @@default_arch,
+                :dependents => data[2].strip.split[1..-1],
+            }
+        else
+            parsed = Package.shell("pacman -Si '#{name}'")
+                .match(@@version_arch_re)
+            if parsed && parsed.length == 3
+                {
+                    :version => parsed[1],
+                    :arch => parsed[2],
+                    # pacman can handle its own dependencies!
+                    :dependents => [],
+                }
+            end
+        end
+    end
+
+    def self.installed_info name
+        Chef::Log.debug("Checking pacman for #{name}")
+        parsed = Package.shell("pacman -Qi '#{name}'").match(@@version_arch_re)
+        if parsed && parsed.length == 3
+            {
+                :version => parsed[1],
+                :arch => parsed[2],
+            }
+        else
+            false
+        end
+    end
+end
+
+class AurDeps
+    include TSort
+
+    def initialize package
+        @package = package
+        @deps = build_dag @package
+    end
+
+    def tsort_each_node &block
+        @deps.each_key(&block)
+    end
+
+    def tsort_each_child name, &block
+        @deps[name].each(&block)
+    end
+
+    def build_dag source
+        deps = {}
+        queue = [source]
+        while not queue.empty?
+            package = queue.shift
+            dependents = package.dependents.map do |dependent|
+                found = Package.shell("pacman -Si #{dependent}").length != 0
+                if !found
+                    out = Package.shell("pacman -Ssq '^#{dependent}$'")
+                    providers = out.split "\n"
+                    if providers.length != 0
+                        # TODO: Support muliple providers
+                        dependent = providers[0]
+                        found = true
+                    end
+                end
+                Package.new dependent, !found
+            end
+            deps[package] = dependents
+            queue += dependents
+        end
+        deps
+    end
+
+    def to_s
+        printed = {}
+        @deps.keys.each do |key|
+            printed[key.to_s] = @deps[key].map { |p| p.to_s }
+        end
+        printed
+    end
+
+    def ordered
+        tsort
+    end
 end

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :build, :install
+actions :build, :install, :sync
 
 default_action :install
 

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -23,7 +23,9 @@ default_action :install
 
 attribute :package_name, :name_attribute => true
 attribute :version, :default => nil
-attribute :builddir, :default => node[:pacman][:build_dir]
+attribute :build_dir, :default => node[:pacman][:build_dir]
+attribute :build_user, :default => node[:pacman][:build_user]
+attribute :build_group, :default => node[:pacman][:build_group]
 attribute :options, :kind_of => String
 attribute :pkgbuild_src, :default => false
 attribute :patches, :kind_of => Array, :default => []


### PR DESCRIPTION
This PR adds the ability to resolve aur and pacman dependencies for aur packages and add the `sync`
action, which will build and install the package if it is not already installed.

This did require quite a bit of refactoring, so I imagine that someone will have opinions about it.
I am **very** new to ruby, so some things might not be idiomatic ruby.